### PR TITLE
Fix for creating bitmap with range and negative number

### DIFF
--- a/lib/bitmap/binary.ex
+++ b/lib/bitmap/binary.ex
@@ -41,7 +41,7 @@ defmodule Bitmap.Binary do
   def new(argument)
   def new(size) when is_integer(size), do: <<0::size(size)>>
   def new(list) when is_list(list), do: new(length(list))
-  def new(a..b), do: new(abs(b - a + 1))
+  def new(a..b), do: new(abs(b - a) + 1)
 
   @doc """
   Returns the bit value at `index` in the bitmap

--- a/lib/bitmap/integer.ex
+++ b/lib/bitmap/integer.ex
@@ -43,7 +43,7 @@ defmodule Bitmap.Integer do
   def new(argument)
   def new(size) when is_integer(size) and size >= 0, do: %__MODULE__{size: size}
   def new(list) when is_list(list), do: new(length(list))
-  def new(a..b), do: new(abs(b - a + 1))
+  def new(a..b), do: new(abs(b - a) + 1)
 
   @doc """
   Returns the bit value at `index` in the bitmap

--- a/test/bitmap_test.exs
+++ b/test/bitmap_test.exs
@@ -12,6 +12,9 @@ defmodule BitmapTest do
     assert Bitmap.Binary.new(0..0) == <<0::size(1)>>
     assert Bitmap.Binary.new(0..10) == <<0, 0::size(3)>>
     assert Bitmap.Binary.new(512..591) == <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert Bitmap.Binary.new(-1..1) == <<0::size(3)>>
+    assert Bitmap.Binary.new(-3..-1) == <<0::size(3)>>
+    assert Bitmap.Binary.new(-1..-3) == <<0::size(3)>>
   end
 
   test "create bitmaps with list" do


### PR DESCRIPTION
It would be a corner case, but I'm assuming the intention is to match the bitmap size with number of elements in a range.
